### PR TITLE
chore: Update license copyright year to 2025

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT LICENSE
 
-Copyright (c) 2015-present Alipay.com, https://www.alipay.com/
+Copyright (c) 2015-2025 Alipay.com, https://www.alipay.com/
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
This pull request makes a minor update to the `LICENSE` file, extending the copyright years for Alipay.com to include 2025.